### PR TITLE
updated exports to deliver types

### DIFF
--- a/examples/types.ts
+++ b/examples/types.ts
@@ -1,0 +1,21 @@
+/*
+ * simple.js
+ */
+
+import { v8 as Todoist, TodoistV8Types } from '..'
+
+const api = Todoist(process.env.TODOIST_API_KEY)
+
+const handleItem = (item: TodoistV8Types.Item) => {
+  /* … Do something with a Todoist-Item */
+}
+
+;(async () => {
+  await api.sync()
+
+  const items /* : TodoistV8Types.Item[] */ = api.items.get()
+  items.map(handleItem)
+
+  const projects /* : TodoistV8Types.Project[] */ = api.projects.get()
+  projects.map(handleItem) // fails, as an item is not compatible with a project
+})()

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
-import { Todoist as v8 } from './v8'
+import { Todoist as TodoistV8 } from './v8'
+import * as TodoistV8Types from './v8-types'
 
-const Todoist = v8
+// export V8 as the current version
+export const Todoist = TodoistV8
 
-export { Todoist, v8 }
+// create backwards compatibility list
+export const v8 = TodoistV8
+// export Types as well
+export { TodoistV8Types }


### PR DESCRIPTION
Adds a simple typescript example to the examples

Adds export of Types to `index.ts` 

Renames internals of `index.ts` but leaves other exports identical