### PR TITLE
added npm badge and installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
-# todoist
+# Todoist
+
+[![npm version](https://badge.fury.io/js/todoist.svg)](https://badge.fury.io/js/todoist)
 
 This module implements v8 of Todoist Sync API described [here](https://doist.github.io/todoist-api/sync/v8/)
+
+## Installation
+
+```
+npm install todoist
+```
+
+or
+
+```
+yarn add todoist
+```
 
 ## Usage
 


### PR DESCRIPTION
closes #11 

* Added NPM badge to show the current live version
* Installation instructions were missing, so it wasn't clear what was the name of the package in NPM